### PR TITLE
Standings dropdown

### DIFF
--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -14,9 +14,9 @@ class Standings extends React.Component {
     }
 
     getWeekOptions() {
-        var weekOptions = [<li><a>all</a></li>]
+        var weekOptions = [<li key='all'><a>all</a></li>]
         for (var i = 1; i <= this.props.current_week; i++) {
-            weekOptions.push(<li><a>{i}</a></li>)
+            weekOptions.push(<li key={i}><a>{i}</a></li>)
         }
 
         return weekOptions

--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -35,15 +35,15 @@ class Standings extends React.Component {
     }
 
     getUserRecordNodes (users) {
-        var last_rank_points = users[0].cur_points;
+        var last_rank_points = users[0].points;
         var last_rank = 1;
 
         return users.map(function(user, index) {
-            if (last_rank_points === user.cur_points ) {
+            if (last_rank_points === user.points ) {
                 user.rank = last_rank;
             } else {
                 user.rank = index + 1;
-                last_rank_points = user.cur_points;
+                last_rank_points = user.points;
                 last_rank = index + 1;
             }
 

--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -1,4 +1,8 @@
 class Standings extends React.Component {
+    componentWillMount () {
+        this.setState({week: 'all'})
+    }
+
     render () {
         var _this = this;
         var userRecordNodes = this.getUserRecordNodes(JSON.parse(this.props.users));

--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -39,10 +39,22 @@ class Standings extends React.Component {
     }
 
     getUserRecordNodes (users) {
-        var last_rank_points = users[0].points;
+        var week = this.state.week
+
+        // sort users
+        users.sort((a, b) => {
+            return b.week_standings[week].points - a.week_standings[week].points
+        })
+
+        // modify user objects for user record component
+        var last_rank_points = users[0].week_standings[week].points;
         var last_rank = 1;
 
         return users.map(function(user, index) {
+            if (week != 'all') {
+                user = Object.assign(user, user.week_standings[week])
+            }
+
             if (last_rank_points === user.points ) {
                 user.rank = last_rank;
             } else {
@@ -52,7 +64,7 @@ class Standings extends React.Component {
             }
 
             return (
-                <UserRecord key={user.id} user={user} />
+                <UserRecord key={user.id} user={user}/>
             );
         });
     }

--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -8,8 +8,13 @@ class Standings extends React.Component {
                 <div className="card-content">
                     <div className="row title-row">
                         <span className="card-title">Standings</span>
+                        <a className='dropdown-button btn' href='#' data-activates='dropdown1'>Week</a>
+                          <ul id='dropdown1' className='dropdown-content'>
+                            <li><a href="#!">1</a></li>
+                            <li><a href="#!">2</a></li>
+                            <li><a href="#!">3</a></li>
+                          </ul>
                     </div>
-
                     <table className="bordered">
                         <tbody>
                             <tr>
@@ -30,15 +35,15 @@ class Standings extends React.Component {
     }
 
     getUserRecordNodes (users) {
-        var last_rank_points = users[0].points;
+        var last_rank_points = users[0].cur_points;
         var last_rank = 1;
 
         return users.map(function(user, index) {
-            if (last_rank_points === user.points ) {
+            if (last_rank_points === user.cur_points ) {
                 user.rank = last_rank;
             } else {
                 user.rank = index + 1;
-                last_rank_points = user.points;
+                last_rank_points = user.cur_points;
                 last_rank = index + 1;
             }
 

--- a/app/assets/javascripts/components/standings.es6.jsx
+++ b/app/assets/javascripts/components/standings.es6.jsx
@@ -3,6 +3,25 @@ class Standings extends React.Component {
         this.setState({week: 'all'})
     }
 
+    componentDidMount() {
+        $('.dropdown-button').dropdown()
+    }
+
+    changeWeek(e) {
+        var text = e.target.text
+        var week = (text === 'all') ? text : parseInt(text)
+        this.setState({week: week})
+    }
+
+    getWeekOptions() {
+        var weekOptions = [<li><a>all</a></li>]
+        for (var i = 1; i <= this.props.current_week; i++) {
+            weekOptions.push(<li><a>{i}</a></li>)
+        }
+
+        return weekOptions
+    }
+
     render () {
         var _this = this;
         var userRecordNodes = this.getUserRecordNodes(JSON.parse(this.props.users));
@@ -12,12 +31,11 @@ class Standings extends React.Component {
                 <div className="card-content">
                     <div className="row title-row">
                         <span className="card-title">Standings</span>
-                        <a className='dropdown-button btn' href='#' data-activates='dropdown1'>Week</a>
-                          <ul id='dropdown1' className='dropdown-content'>
-                            <li><a href="#!">1</a></li>
-                            <li><a href="#!">2</a></li>
-                            <li><a href="#!">3</a></li>
-                          </ul>
+                        <a className='dropdown-button btn' data-activates='dropdown1'>Week: {this.state.week}</a>
+
+                        <ul id='dropdown1' className='dropdown-content' onClick={this.changeWeek.bind(this)}>
+                            {this.getWeekOptions()}
+                        </ul>
                     </div>
                     <table className="bordered">
                         <tbody>

--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -3,9 +3,7 @@ class PicksController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @picks = @user
-              .picks
-              .includes([:game => [:home_team, :away_team]])
+    @picks = @user.picks.includes([:game => [:home_team, :away_team]])
     @weeks = (1...current_week+1).to_a.reverse
   end
 
@@ -44,9 +42,7 @@ class PicksController < ApplicationController
   end
 
   def previous
-    @picks = current_user
-              .picks
-              .includes([:game => [:home_team, :away_team]])
+    @picks = current_user.picks.includes([:game => [:home_team, :away_team]])
     @weeks = (1...current_week+1).to_a.reverse
     render "index"
   end

--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -48,6 +48,7 @@ class PicksController < ApplicationController
   end
 
   def standings
+    @current_week = current_week
     @users = User.where.not(id: [64, 65, 66]).all.to_a
       .to_json(:methods => [:wins, :losses, :pushes, :percent, :points, :week_standings])
   end

--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -48,8 +48,8 @@ class PicksController < ApplicationController
   end
 
   def standings
-    @users = User.where.not(id: [64, 65, 66]).all.to_a.sort_by(&:points).
-    reverse.to_json(:methods => [:wins, :losses, :pushes, :percent, :points])
+    @users = User.where.not(id: [64, 65, 66]).all.to_a
+      .to_json(:methods => [:wins, :losses, :pushes, :percent, :points, :week_standings])
   end
 
   def distribution

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,59 +57,34 @@ class User < ApplicationRecord
     end
   end
 
-  def cur_wins
-    week = Game.get_week
-    picks.where(:result => 'win').where(:week => week).count
-  end
-
-  def cur_losses
-    week = Game.get_week
-    picks.where(:result => 'loss').where(:week => week).count
-  end
-
-  def cur_pushes
-    week = Game.get_week
-    picks.where(:result => 'push').where(:week => week).count
-  end
-
-  def cur_points
-    cur_wins + (cur_pushes * 0.5)
-  end
-
-  def cur_percent
-    total = cur_wins + cur_losses + cur_pushes
-    if total > 0
-      perc = cur_points  / total * 100
-      perc.round()
-    else
-      return 0
-    end
-  end
-  #
   def week_standings
     week = Game.get_week
-    @week_standings = Hash.new
+    week_standings = Hash.new
     week.downto(1).each do |this_week|
-      wins = picks.where(:result => 'win').where(:week => this_week).count
-      pushes = picks.where(:result => 'push').where(:week => this_week).count
-      losses = picks.where(:result => 'loss').where(:week => this_week).count
-      points = wins + (pushes * 0.5)
-      total = wins + losses + pushes
+      week_wins = picks.where(:result => 'win', :week => this_week).count
+      week_pushes = picks.where(:result => 'push', :week => this_week).count
+      week_losses = picks.where(:result => 'loss', :week => this_week).count
+      week_points = week_wins + (week_pushes * 0.5)
+      total = week_wins + week_losses + week_pushes
       if total > 0
-        perc = points  / total * 100
+        perc = week_points  / total * 100
         perc.round()
       else
         perc = 0
       end
 
-    @week_standings[this_week] = {
-      :wins => wins,
-      :pushes => pushes,
-      :losses => losses,
-      :points => points,
-      :perc => perc
-    }
+      week_standings[this_week] = {
+        :wins => week_wins,
+        :pushes => week_pushes,
+        :losses => week_losses,
+        :points => week_points,
+        :perc => perc
+      }
     end
+
+    percentage_all = (points / picks.count) * 100
+    week_standings[:all] = {wins: wins, pushes: pushes, points: points, perc: percentage_all}
+    week_standings
   end
 
   def get_picks_summary(week)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,32 +57,59 @@ class User < ApplicationRecord
     end
   end
 
-  def week_standings(week)
-    week_standings = {}
-    # @weeks_standings = Hash.new
-    week.downto(1).each do |this_week|
-          # @week_standings[this_week] = []
-          wins = picks.where(:result => 'win').where(:week => this_week).count
-          pushes = picks.where(:result => 'push').where(:week => this_week).count
-          losses = picks.where(:result => 'loss').where(:week => this_week).count
-          points = wins + (pushes * 0.5)
-          total = wins + losses + pushes
-          if total > 0
-            perc = points  / total * 100
-            perc.round()
-          else
-            perc = 0
-          end
+  def cur_wins
+    week = Game.get_week
+    picks.where(:result => 'win').where(:week => week).count
+  end
 
-          week_standings[this_week] = {
-            :wins => wins,
-            :pushes => pushes,
-            :losses => losses,
-            :points => points,
-            :perc => perc
-          }
+  def cur_losses
+    week = Game.get_week
+    picks.where(:result => 'loss').where(:week => week).count
+  end
+
+  def cur_pushes
+    week = Game.get_week
+    picks.where(:result => 'push').where(:week => week).count
+  end
+
+  def cur_points
+    cur_wins + (cur_pushes * 0.5)
+  end
+
+  def cur_percent
+    total = cur_wins + cur_losses + cur_pushes
+    if total > 0
+      perc = cur_points  / total * 100
+      perc.round()
+    else
+      return 0
     end
-    week_standings
+  end
+  #
+  def week_standings
+    week = Game.get_week
+    @week_standings = Hash.new
+    week.downto(1).each do |this_week|
+      wins = picks.where(:result => 'win').where(:week => this_week).count
+      pushes = picks.where(:result => 'push').where(:week => this_week).count
+      losses = picks.where(:result => 'loss').where(:week => this_week).count
+      points = wins + (pushes * 0.5)
+      total = wins + losses + pushes
+      if total > 0
+        perc = points  / total * 100
+        perc.round()
+      else
+        perc = 0
+      end
+
+    @week_standings[this_week] = {
+      :wins => wins,
+      :pushes => pushes,
+      :losses => losses,
+      :points => points,
+      :perc => perc
+    }
+    end
   end
 
   def get_picks_summary(week)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,24 +66,19 @@ class User < ApplicationRecord
       week_losses = picks.where(:result => 'loss', :week => this_week).count
       week_points = week_wins + (week_pushes * 0.5)
       total = week_wins + week_losses + week_pushes
-      if total > 0
-        perc = week_points  / total * 100
-        perc.round()
-      else
-        perc = 0
-      end
+      percent = total > 0 ? (week_points  / total * 100).round : 0
 
       week_standings[this_week] = {
         :wins => week_wins,
         :pushes => week_pushes,
         :losses => week_losses,
         :points => week_points,
-        :perc => perc
+        :percent => percent
       }
     end
 
     percentage_all = (points / picks.count) * 100
-    week_standings[:all] = {wins: wins, pushes: pushes, points: points, perc: percentage_all}
+    week_standings[:all] = {wins: wins, pushes: pushes, points: points, percent: percentage_all.round}
     week_standings
   end
 

--- a/app/views/picks/index.html.erb
+++ b/app/views/picks/index.html.erb
@@ -4,7 +4,7 @@
 	<% end %>
 	<% @weeks.each do |week| %>
 		<%= react_component('GameList', {
-			games: @picks.where(:week => week).where.not(:result => nil).map { |pick|
+			games: @picks.where(:week => week).joins(:game).where("games.time < ?", Time.now).map { |pick|
 				game = pick.game.as_json({:include => [:home_team, :away_team]})
 				game['pick'] = pick.as_json
 				game

--- a/app/views/picks/standings.html.erb
+++ b/app/views/picks/standings.html.erb
@@ -1,3 +1,4 @@
 <%= react_component('Standings', {
-	users: @users
+	users: @users,
+	current_week: @current_week
 }, {class: 'col s10'}) %>


### PR DESCRIPTION
@shaundre3000 should all be working - didn't test thoroughly though, and didn't do much styling or positioning for the dropdown I'll leave that to you.

The way we're currently populating the weekly standings per user is pretty inefficient, for each week we're running multiple count queries which are expensive. 50 users * n weeks * 3 (wins, losses, pushes) = lots and lots of unnecessary queries per page load.. instead we should gather all the picks for a user and just loop through them since all the data is there already. I didn't clean that up just because i didn't have too much time to work on this, but it's something to do if we want to speed up page load for /standings .